### PR TITLE
wrap platform specific bluetooth implementations in a generic header …

### DIFF
--- a/src/main/connector/bluetooth/BluetoothConnector.h
+++ b/src/main/connector/bluetooth/BluetoothConnector.h
@@ -1,0 +1,39 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *  Presenter. Server software to remote control a presentation.         *
+ *  Copyright (C) 2017 Felix Wohlfrom                                    *
+ *                                                                       *
+ *  This program is free software: you can redistribute it and/or modify *
+ *  it under the terms of the GNU General Public License as published by *
+ *  the Free Software Foundation, either version 3 of the License, or    *
+ *  (at your option) any later version.                                  *
+ *                                                                       *
+ *  This program is distributed in the hope that it will be useful,      *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of       *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        *
+ *  GNU General Public License for more details.                         *
+ *                                                                       *
+ *  You should have received a copy of the GNU General Public License    *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.*
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/*
+ * BluetoothConnector.h
+ *
+ *  Created on: 10.11.2017
+ *      Author: Felix Wohlfrom
+ */
+
+#ifndef SRC_MAIN_CONNECTOR_BLUETOOTH_BLUETOOTHCONNECTOR_H_
+#define SRC_MAIN_CONNECTOR_BLUETOOTH_BLUETOOTHCONNECTOR_H_
+
+// This is just a wrapper class that will include either the linux or windows
+// specific implementation of the bluetooth connector class.
+
+#ifdef _WIN32
+    #include "../connector/bluetooth/BluetoothConnector_Windows.h"
+#endif // _WIN32
+#ifdef __linux__
+    #include "../connector/bluetooth/BluetoothConnector_Linux.h"
+#endif // __linux__
+
+#endif /* SRC_MAIN_CONNECTOR_BLUETOOTH_BLUETOOTHCONNECTOR_H_ */

--- a/src/main/connector/bluetooth/CMakeLists.txt
+++ b/src/main/connector/bluetooth/CMakeLists.txt
@@ -6,6 +6,7 @@ SET(SOURCE
 
 SET(HEADERS
     BluetoothConnectorBase.h
+    BluetoothConnector.h
     key_sender.h
 )
 

--- a/src/main/gui/MainWindow.cpp
+++ b/src/main/gui/MainWindow.cpp
@@ -28,13 +28,6 @@
 
 #include "AboutWindow.h"
 
-#ifdef _WIN32
-    #include "../connector/bluetooth/BluetoothConnector_Windows.h"
-#endif // _WIN32
-#ifdef __linux__
-    #include "../connector/bluetooth/BluetoothConnector_Linux.h"
-#endif // __linux__
-
 #include <QIcon>
 #include <QMenu>
 #include <QCloseEvent>

--- a/src/main/gui/MainWindow.h
+++ b/src/main/gui/MainWindow.h
@@ -30,7 +30,7 @@
 
 #include <QMainWindow>
 
-#include "../connector/bluetooth/BluetoothConnectorBase.h"
+#include "../connector/bluetooth/BluetoothConnector.h"
 
 namespace Ui {
     class MainWindow;
@@ -120,7 +120,7 @@ class MainWindow : public QMainWindow
         /**
          * The bluetooth connector class. Will create the bluetooth server.
          */
-        BluetoothConnectorBase* btConnector;
+        BluetoothConnector* btConnector;
 
         /**
          * The action to open our log window.


### PR DESCRIPTION
…file

add new BluetoothConnector.h header file that will include either the
windows or linux specific implementation. This makes the interface more
clear for the gui classes.