### PR TITLE
add support for gnome shell which doesn't have a system tray

### DIFF
--- a/src/main/Main.cpp
+++ b/src/main/Main.cpp
@@ -64,13 +64,10 @@ int main(int argc, char *argv[])
 
     QApplication app(argc, argv);
 
-    if (!QSystemTrayIcon::isSystemTrayAvailable()) {
-        QMessageBox::critical(0, QObject::tr("Presenter"),
-                QObject::tr("System tray not detected on this system"));
-        return 1;
+    if (QSystemTrayIcon::isSystemTrayAvailable())
+    {
+      QApplication::setQuitOnLastWindowClosed(false);
     }
-
-    QApplication::setQuitOnLastWindowClosed(false);
 
     MainWindow window;
     window.show();

--- a/src/main/gui/MainWindow.cpp
+++ b/src/main/gui/MainWindow.cpp
@@ -142,7 +142,8 @@ void MainWindow::showAboutScreen()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-    if (trayIcon->isVisible()) {
+    if (QSystemTrayIcon::isSystemTrayAvailable()
+            && trayIcon->isVisible()) {
         if (trayIcon->supportsMessages()) {
             trayIcon->showMessage(tr("Presenter"),
                                  tr("The program will keep running in the "
@@ -160,6 +161,10 @@ void MainWindow::closeEvent(QCloseEvent *event)
         }
 
         hide();
+        event->ignore();
+
+    } else {
+        showMinimized();
         event->ignore();
     }
 }


### PR DESCRIPTION
now, if a system tray is not available, instead of failing to start,
minimize the main window instead of closing (similar to minimizing to tray
on systems that support it).