### PR TITLE
fix hanging of windows bluetooth server if client was still connected

### DIFF
--- a/src/main/connector/bluetooth/BluetoothConnector_Windows.cpp
+++ b/src/main/connector/bluetooth/BluetoothConnector_Windows.cpp
@@ -303,6 +303,15 @@ BluetoothReaderThread::BluetoothReaderThread(const SOCKET serverSocket) :
 
 void BluetoothReaderThread::stop()
 {
+    // Close the connection
+    if (closesocket(clientSocket) == SOCKET_ERROR)
+    {
+        emit error(QString("Could not close socket 0x%1. %2\n")
+                .arg((ULONG64)serverSocket, 16)
+                .arg(BluetoothConnector::getLastWSAError()));
+        QCoreApplication::processEvents();
+    }
+
     keepRunning = false;
 }
 


### PR DESCRIPTION
Stop the connection to avoid hanging of the process.
This fixes #15.