### PR TITLE
fix closing of server if no client is connected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ services:
   - docker
 
 before_install:
-  - docker pull ubuntu:16.10
-  - docker run -w /root --name test -d ubuntu:16.10 sleep infinity
+  - docker pull ubuntu:17.10
+  - docker run -w /root --name test -d ubuntu:17.10 sleep infinity
   - docker cp . test:/root/
 
 install:


### PR DESCRIPTION
Before, the server was crashing if it was closed with no client connected.
This happened since the server was not able to close and tried to log some
error.