### PR TITLE
fix crash on windows on closing if no client is connected

### DIFF
--- a/src/main/connector/bluetooth/BluetoothConnector_Windows.cpp
+++ b/src/main/connector/bluetooth/BluetoothConnector_Windows.cpp
@@ -304,7 +304,8 @@ BluetoothReaderThread::BluetoothReaderThread(const SOCKET serverSocket) :
 void BluetoothReaderThread::stop()
 {
     // Close the connection
-    if (closesocket(clientSocket) == SOCKET_ERROR)
+    if (clientSocket != INVALID_SOCKET &&
+        closesocket(clientSocket) == SOCKET_ERROR)
     {
         emit error(QString("Could not close socket 0x%1. %2\n")
                 .arg((ULONG64)serverSocket, 16)


### PR DESCRIPTION
If no client is connected, we tried still to close the socket.
Now we close the clientSocket only if it still is connected.